### PR TITLE
add area:highway=footway rendering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -677,8 +677,8 @@ Layer:
             ) AS feature
           FROM planet_osm_polygon
           WHERE highway IN ('pedestrian', 'footway', 'service', 'platform')
-            OR (railway IN ('platform')
             OR (tags->'area:highway') in ('footway', 'pedestrian')
+            OR (railway IN ('platform')
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                 AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
                 AND (covered NOT IN ('yes') OR covered IS NULL))
@@ -803,8 +803,8 @@ Layer:
             ) AS feature
           FROM planet_osm_polygon
           WHERE highway IN ('pedestrian', 'footway', 'service', 'living_street', 'platform', 'services')
-            OR (railway IN ('platform')
             OR (tags->'area:highway') in ('footway', 'pedestrian')
+            OR (railway IN ('platform')
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                 AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
                 AND (covered NOT IN ('yes') OR covered IS NULL))

--- a/project.mml
+++ b/project.mml
@@ -666,8 +666,9 @@ Layer:
       table: |-
         (SELECT
             way,
-            COALESCE((
-              'highway_' || (CASE WHEN highway IN ('pedestrian', 'footway', 'service', 'platform') THEN highway END)),
+            COALESCE(
+              ('highway_' || (CASE WHEN highway IN ('pedestrian', 'footway', 'service', 'platform') THEN highway END)),
+              ('highway_area_' || (tags->'area:highway')),
               ('railway_' || (CASE WHEN (railway IN ('platform')
                               AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                               AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
@@ -677,6 +678,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE highway IN ('pedestrian', 'footway', 'service', 'platform')
             OR (railway IN ('platform')
+            OR (tags->'area:highway') in ('footway', 'pedestrian')
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                 AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
                 AND (covered NOT IN ('yes') OR covered IS NULL))
@@ -791,6 +793,7 @@ Layer:
             COALESCE(
               ('highway_' || (CASE WHEN highway IN ('pedestrian', 'footway', 'service', 'living_street',
                                                     'platform', 'services') THEN highway END)),
+              ('highway_area_' || (tags->'area:highway')),
               ('railway_' || (CASE WHEN (railway IN ('platform')
                               AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                               AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
@@ -801,6 +804,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE highway IN ('pedestrian', 'footway', 'service', 'living_street', 'platform', 'services')
             OR (railway IN ('platform')
+            OR (tags->'area:highway') in ('footway', 'pedestrian')
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                 AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
                 AND (covered NOT IN ('yes') OR covered IS NULL))

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2684,6 +2684,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
   }
 
+  [feature = 'highway_area_footway'],
+  [feature = 'highway_area_pedestrian'],
   [feature = 'highway_footway'],
   [feature = 'highway_pedestrian'] {
     [zoom >= 15] {
@@ -2714,6 +2716,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
   }
 
+  [feature = 'highway_area_footway'],
+  [feature = 'highway_area_pedestrian'],
   [feature = 'highway_footway'],
   [feature = 'highway_pedestrian'] {
     [zoom >= 15] {


### PR DESCRIPTION
Changes proposed in this pull request:
- Dodanie renderowania `area:highway=footway` tak jak `highway=footway`+`area=yes`

Test rendering with links to the example places:
https://www.openstreetmap.org/#map=19/52.40790/16.92995

W górnej części jest chodnik z samym `area:highway` a w dolnej z `area=yes`+`highway=footway`

Before
![image](https://user-images.githubusercontent.com/19535945/125128041-b6041280-e0fd-11eb-8325-7ae114a232dd.png)

After
![image](https://user-images.githubusercontent.com/19535945/125127921-8fde7280-e0fd-11eb-8efe-c1955385ec61.png)